### PR TITLE
Return early if the rootUrl is just `/`

### DIFF
--- a/util.js
+++ b/util.js
@@ -56,7 +56,7 @@ function removeRootURL(config) {
   // extract and parse the application config
   let appConfig = JSON.parse(decodeURIComponent(config.meta[0].content));
   let { rootURL } = appConfig;
-	if (!rootURL) return config;
+	if (!rootURL || rootURL === '/') return config;
 	config.script = config.script.map(s => {
 		s.src = s.src.replace(rootURL, './');
 		return s;


### PR DESCRIPTION
* For apps with external scripts and a rootUrl of
  `/`, this ends up outputting `https:.//example.com`